### PR TITLE
Refactor Lounge page pagenation #14

### DIFF
--- a/src/Components/Pagenation.tsx
+++ b/src/Components/Pagenation.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PRIMARY_COLOR_BLUE } from "../Constants/constants";
+import { PRIMARY_COLOR_BLUE, PRIMARY_COLOR_B } from "../Constants/constants";
 import styled from "styled-components";
 import { BiChevronLeft, BiChevronRight } from "react-icons/bi";
 
@@ -77,13 +77,13 @@ const BottomCheckLink = styled.div`
   height: 35px;
 
   &:hover {
-    background-color: ${PRIMARY_COLOR_BLUE};
+    background-color: ${PRIMARY_COLOR_B};
     color: white;
   }
 `;
 
 const BottomCheckButton = styled.button`
-  background-color: ${PRIMARY_COLOR_BLUE};
+  background-color: ${PRIMARY_COLOR_B};
   border: 1px solid ${PRIMARY_COLOR_BLUE};
   display: flex;
   align-items: center;

--- a/src/Constants/constants.tsx
+++ b/src/Constants/constants.tsx
@@ -1,3 +1,4 @@
 export const PRIMARY_COLOR_SKY = "#b7c9e2";
 export const PRIMARY_COLOR_WHITE = "#f8f5f1";
-export const PRIMARY_COLOR_BLUE = "#6fbcca";
+export const PRIMARY_COLOR_BLUE = "#6f99ca";
+export const PRIMARY_COLOR_B = "#1265d1";

--- a/src/Lounge/Lboard.tsx
+++ b/src/Lounge/Lboard.tsx
@@ -3,10 +3,12 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import Pagenation from "../Components/Pagenation";
 import LoungeMain from "./LoungeMain";
+import { ImArrowLeft } from "react-icons/im";
 import {
   PRIMARY_COLOR_WHITE,
   PRIMARY_COLOR_SKY,
   PRIMARY_COLOR_BLUE,
+  PRIMARY_COLOR_B,
 } from "../Constants/constants";
 import axios from "axios";
 interface Ct {
@@ -26,13 +28,20 @@ const Lboard = () => {
   }, []);
   return (
     <MainContain>
-      <LoungeTop>최신 게시판</LoungeTop>
+      <LoungeTop>
+        <LinkTop to="/Lounge">
+          <ImArrowLeft />
+        </LinkTop>
+        최신 게시판
+      </LoungeTop>
 
       <Loungemargin>
-        <LoungeMain showCount={8} />
+        <LoungeMain
+          showCount={pagecontent.slice((currentpage - 1) * 8, currentpage * 8)}
+        />
         <Loungebottom>
           <Pagenation
-            eight={5}
+            eight={8}
             currentpage={currentpage}
             total={pagecontent.length}
             setPage={setCurrentPage}
@@ -53,7 +62,12 @@ const Loungebottom = styled.div`
   justify-content: space-around;
   background-color: ${PRIMARY_COLOR_BLUE};
 `;
-
+const LinkTop = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: black;
+`;
 const LoungeLink = styled(Link)`
   background-color: ${PRIMARY_COLOR_SKY};
   color: ${PRIMARY_COLOR_WHITE};
@@ -65,13 +79,17 @@ const LoungeLink = styled(Link)`
   align-items: center;
   justify-content: center;
   &:hover {
-    background-color: ${PRIMARY_COLOR_BLUE};
+    background-color: ${PRIMARY_COLOR_B};
     color: white;
     transition: 1s;
   }
 `;
 const LoungeTop = styled.h1`
-  width: 900px;
+  width: 300px;
+  display: flex;
+
+  justify-content: space-around;
+  margin-right: 650px;
 `;
 const Loungemargin = styled.div`
   display: flex;

--- a/src/Lounge/Lounge.tsx
+++ b/src/Lounge/Lounge.tsx
@@ -13,7 +13,11 @@ interface MainDB {
   id: number;
   images: string;
 }
-
+interface Ct {
+  title: string;
+  img: string;
+  id: string;
+}
 const Lounge: React.FC<MainProps> = ({ isSidebarOpen }) => {
   const [pL, setPL] = useState(0);
   const [main, setMain] = useState<MainDB[]>([]);
@@ -39,6 +43,15 @@ const Lounge: React.FC<MainProps> = ({ isSidebarOpen }) => {
     slidesToShow: 1,
     slidesToScroll: 1,
   };
+  const [pagecontent, setPageContent] = useState<Ct[]>([]);
+
+  useEffect(() => {
+    async function fetchPageContent() {
+      const result = await axios.get("http://localhost:3001/Community");
+      setPageContent(result.data);
+    }
+    fetchPageContent();
+  }, []);
 
   return (
     <MainContain paddingLeft={pL}>
@@ -48,7 +61,7 @@ const Lounge: React.FC<MainProps> = ({ isSidebarOpen }) => {
             <h1>최신 게시판</h1> <LoungeLink to="/Lboard">더보기</LoungeLink>
           </Llefttoptitle>
           <LMtop>
-            <LoungeMain showCount={7} />
+            <LoungeMain showCount={pagecontent.slice(0, 8)} />
           </LMtop>
         </Lcomponent>
 
@@ -57,7 +70,7 @@ const Lounge: React.FC<MainProps> = ({ isSidebarOpen }) => {
             <h1>친구 구해요</h1> <LoungeLink to="/Lboard">더보기</LoungeLink>
           </Llefttoptitle>
           <LMbottom>
-            <LoungeMain showCount={4} />
+            <LoungeMain showCount={pagecontent.slice(0, 4)} />
           </LMbottom>
         </Lcomponent>
       </Lentire>
@@ -70,7 +83,7 @@ const Lounge: React.FC<MainProps> = ({ isSidebarOpen }) => {
             <h1>인기 게시판</h1> <LoungeLink to="/Lboard">더보기</LoungeLink>
           </Llefttoptitle>
           <LMtop>
-            <LoungeMain showCount={7} />
+            <LoungeMain showCount={pagecontent.slice(0, 8)} />
           </LMtop>
         </Lcomponent>
       </Lentire>

--- a/src/Lounge/LoungeMain.tsx
+++ b/src/Lounge/LoungeMain.tsx
@@ -1,12 +1,8 @@
-import React, { useState, useEffect } from "react";
-import axios from "axios";
+import React from "react";
+import { PRIMARY_COLOR_B } from "../Constants/constants";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { FaHeart } from "react-icons/fa6";
-
-interface LoungeMainProps {
-  showCount?: number;
-}
 
 interface community {
   id: string;
@@ -16,29 +12,14 @@ interface community {
   contents: string;
   hash: string;
 }
+interface info {
+  showCount: any;
+}
 
-function LoungeMain({ showCount }: LoungeMainProps) {
-  const [commu, setCommu] = useState<community[]>([]);
-
-  useEffect(() => {
-    axios
-      .get("http://localhost:3001/Community")
-      .then((res) => {
-        setCommu(res.data);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  }, []);
-
-  let displayedData = commu;
-  if (showCount !== undefined) {
-    displayedData = commu.slice(0, showCount);
-  }
-
+const LoungeMain: React.FC<info> = ({ showCount }) => {
   return (
     <>
-      {displayedData.map((b) => (
+      {showCount.map((b: community) => (
         <Loungein key={b.id} to={`/Community/${b.id}`}>
           <Loungein2>
             <div>{b.title}</div>
@@ -53,7 +34,7 @@ function LoungeMain({ showCount }: LoungeMainProps) {
       ))}
     </>
   );
-}
+};
 
 export default LoungeMain;
 
@@ -82,6 +63,11 @@ const Loungein = styled(Link)`
   display: Flex;
 
   border-top: 1px solid black;
+  &:hover {
+    transition: all 2s;
+    background-color: ${PRIMARY_COLOR_B};
+    color: white;
+  }
 `;
 const Incontents = styled.div`
   width: 450px;

--- a/src/MainCafePage/PostMainBoxForm.tsx
+++ b/src/MainCafePage/PostMainBoxForm.tsx
@@ -53,9 +53,9 @@ const PostMainBoxForm: React.FC<PostCafeProps> = () => {
       }
     }
   };
-  const handleRemoveImage = (index: number, e:React.MouseEvent) => {
+  const handleRemoveImage = (index: number, e: React.MouseEvent) => {
     //기본 동작 방지(이미지 x버튼 누르면 파일 첨부까지 함께 눌러짐.)
-    e.preventDefault(); 
+    e.preventDefault();
 
     const newImages = [...images];
     newImages.splice(index, 1);
@@ -105,7 +105,7 @@ const PostMainBoxForm: React.FC<PostCafeProps> = () => {
                 {file.name}
                 <StyledBTN
                   type="button"
-                  onClick={(e) => handleRemoveImage(index,e)}
+                  onClick={(e) => handleRemoveImage(index, e)}
                 />
               </div>
             ))}

--- a/src/json-server/db.json
+++ b/src/json-server/db.json
@@ -159,157 +159,157 @@
       "img": "https://media.istockphoto.com/id/1428594094/ko/%EC%82%AC%EC%A7%84/%EB%82%98%EB%AC%B4-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%BB%A4%ED%94%BC-%EB%A9%94%EC%9D%B4%EC%BB%A4-%ED%8C%A8%EC%8A%A4%ED%8A%B8%EB%A6%AC-%EB%B0%8F-%ED%8E%9C%EB%8D%98%ED%8A%B8-%EC%A1%B0%EB%AA%85%EC%9D%B4%EC%9E%88%EB%8A%94-%EB%B9%88-%EC%BB%A4%ED%94%BC-%EC%88%8D-%EC%9D%B8%ED%85%8C%EB%A6%AC%EC%96%B4.jpg?s=612x612&w=0&k=20&c=5bHJXVEZ4D9zsN_ZV-XVZsTxwxL5GdUOo5D0PPs3fsI="
     },
     {
-      "id": "30",
+      "id": "9",
       "title": "강서2",
       "img": "https://i.namu.wiki/i/5FGUIiyTGl3EkaSlnnRnmoAsPBMkL8w1tVdj5pgDOoydk2T0brSqYsWyLgGqyELwn5oP8HWRhF8A-p8ZyN4FtQ.webp"
     },
     {
-      "id": "29",
+      "id": "10",
       "title": "인천2",
       "img": "https://static.hyundailivart.co.kr/upload_mall/board/ME00000045/B200033624/tplt/0000207217_ImgPath.jpg/dims/autorotate/on"
     },
     {
-      "id": "28",
+      "id": "11",
       "title": "김포2",
       "img": "https://vmspace.com/ActiveFile/spacem.org/project/2-2.%20%BD%BA%C5%B8%B9%F7%BD%BA%20%B5%B5%C4%EC%20%A8%CFLee%20Jeonghoon%20%282%29.jpg"
     },
     {
-      "id": "27",
+      "id": "12",
       "title": "당정2",
       "img": "https://media.istockphoto.com/id/1130595856/ko/%EC%82%AC%EC%A7%84/%EC%B9%B4%ED%8E%98%EC%97%90%EC%84%9C-%EC%BB%A4%ED%94%BC-%EC%8B%9C%EA%B0%84-%EB%8F%99%EC%95%88-%EC%9E%AC%EB%AF%B8-%EB%91%90-%EC%BE%8C%ED%99%9C-%ED%95%9C-%EC%97%AC%EC%9E%90.jpg?s=612x612&w=0&k=20&c=XZ5O3bMz_zg2dvcPLEwTcXHUw6jZkf9v3mCE1-rdYj0="
     },
     {
-      "id": "26",
+      "id": "13",
       "title": "홍대2",
       "img": "https://images.chosun.com/resizer/Vcz9jBB26OGypGQQL96knn4a_Fc=/616x0/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosun/K7FSANZHUFGXPG6HHTKUJE3GSA.jpg"
     },
     {
-      "id": "25",
+      "id": "14",
       "title": "이태원2",
       "img": "https://i.namu.wiki/i/5FGUIiyTGl3EkaSlnnRnmoAsPBMkL8w1tVdj5pgDOoydk2T0brSqYsWyLgGqyELwn5oP8HWRhF8A-p8ZyN4FtQ.webp"
     },
     {
-      "id": "24",
+      "id": "15",
       "title": "강남2",
       "img": "https://a.cdn-hotels.com/gdcs/production161/d1403/b5f1876a-9e64-4d13-ab7a-a0fd2cbc5224.jpg"
     },
     {
-      "id": "23",
+      "id": "16",
       "title": "판교2",
       "img": "https://i.namu.wiki/i/5FGUIiyTGl3EkaSlnnRnmoAsPBMkL8w1tVdj5pgDOoydk2T0brSqYsWyLgGqyELwn5oP8HWRhF8A-p8ZyN4FtQ.webp"
     },
     {
-      "id": "31",
+      "id": "17",
       "title": "강서3",
       "img": "https://a.cdn-hotels.com/gdcs/production161/d1403/b5f1876a-9e64-4d13-ab7a-a0fd2cbc5224.jpg"
     },
     {
-      "id": "32",
+      "id": "18",
       "title": "인천3",
       "img": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSKLuRjfRKoH0XxE77KnZ4_OrZV5Mc3B6nivQHR1QNvFQ&s"
     },
     {
-      "id": "33",
+      "id": "19",
       "title": "김포3",
       "img": "https://i.namu.wiki/i/5FGUIiyTGl3EkaSlnnRnmoAsPBMkL8w1tVdj5pgDOoydk2T0brSqYsWyLgGqyELwn5oP8HWRhF8A-p8ZyN4FtQ.webp"
     },
     {
-      "id": "34",
+      "id": "20",
       "title": "당정3",
       "img": "https://cdn.imweb.me/thumbnail/20230522/31017371829ad.jpg"
     },
     {
-      "id": "35",
+      "id": "21",
       "title": "3",
       "img": "https://www.qplace.kr/content/images/2022/10/No.3185------.jpg"
     },
     {
-      "id": "36",
+      "id": "22",
       "title": "이태원3",
       "img": "https://media.istockphoto.com/id/1286692956/ko/%EC%82%AC%EC%A7%84/%EC%9D%98%EC%9E%90%EC%99%80-%ED%85%8C%EC%9D%B4%EB%B8%94%EC%9D%B4-%EC%9E%88%EB%8A%94-%EB%B9%88-%EC%B9%B4%ED%8E%98-%EC%9D%B8%ED%85%8C%EB%A6%AC%EC%96%B4.jpg?s=612x612&w=0&k=20&c=dgWlZUPam-dJb_bRpXqCPUyRd-UWaYxCKiFkJT4fYSQ="
     },
     {
-      "id": "37",
+      "id": "23",
       "title": "강남3",
       "img": "https://gyeongju.go.kr/upload/content/thumb/20200429/AF0FBCACF6E141DEBAD30FDB6082D979.jpg"
     },
     {
-      "id": "38",
+      "id": "24",
       "title": "판교3",
       "img": "https://media.istockphoto.com/id/1428594094/ko/%EC%82%AC%EC%A7%84/%EB%82%98%EB%AC%B4-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%BB%A4%ED%94%BC-%EB%A9%94%EC%9D%B4%EC%BB%A4-%ED%8C%A8%EC%8A%A4%ED%8A%B8%EB%A6%AC-%EB%B0%8F-%ED%8E%9C%EB%8D%98%ED%8A%B8-%EC%A1%B0%EB%AA%85%EC%9D%B4%EC%9E%88%EB%8A%94-%EB%B9%88-%EC%BB%A4%ED%94%BC-%EC%88%8D-%EC%9D%B8%ED%85%8C%EB%A6%AC%EC%96%B4.jpg?s=612x612&w=0&k=20&c=5bHJXVEZ4D9zsN_ZV-XVZsTxwxL5GdUOo5D0PPs3fsI="
     },
     {
-      "id": "9",
+      "id": "25",
       "title": "강서4",
       "img": "https://img.hankyung.com/photo/202209/01.31363897.1.jpg"
     },
     {
-      "id": "10",
+      "id": "26",
       "title": "인천4",
       "img": "https://img.freepik.com/premium-photo/generative-ai-a-large-bright-cafe-environment-with-chairs-concrete-walls-and-a-hardwood-floor_28914-19636.jpg"
     },
     {
-      "id": "11",
+      "id": "27",
       "title": "김포4",
       "img": "https://cdn-std-web-247-249.cdn-nhncommerce.com/vanessa19_godomall_com/data/skin/front/story_g/img/c_b_1200.jpg"
     },
     {
-      "id": "12",
+      "id": "28",
       "title": "당정4",
       "img": "https://a.cdn-hotels.com/gdcs/production49/d672/dfcca789-023a-490f-8f1a-46bc6a969000.jpg?impolicy=fcrop&w=800&h=533&q=medium"
     },
     {
-      "id": "13",
+      "id": "29",
       "title": "홍대4",
       "img": "https://i2.wp.com/baristanews.co.kr/wp-content/uploads/bs-mocopan-june-lrg-1680x880.jpg?fit=1680%2C880&ssl=1"
     },
     {
-      "id": "14",
+      "id": "30",
       "title": "이태원4",
       "img": "https://a.cdn-hotels.com/gdcs/production161/d1403/b5f1876a-9e64-4d13-ab7a-a0fd2cbc5224.jpg"
     },
     {
-      "id": "15",
+      "id": "31",
       "title": "강남4",
       "img": "https://cdn.imweb.me/thumbnail/20230522/31017371829ad.jpg"
     },
     {
-      "id": "16",
+      "id": "32",
       "title": "판교4",
       "img": "https://www.qplace.kr/content/images/2022/10/No.3185------.jpg"
     },
     {
-      "id": "17",
+      "id": "33",
       "title": "강서5",
       "img": "https://gyeongju.go.kr/upload/content/thumb/20200429/AF0FBCACF6E141DEBAD30FDB6082D979.jpg"
     },
     {
-      "id": "18",
+      "id": "34",
       "title": "인천5",
       "img": "https://img.freepik.com/premium-photo/generative-ai-a-large-bright-cafe-environment-with-chairs-concrete-walls-and-a-hardwood-floor_28914-19636.jpg"
     },
     {
-      "id": "19",
+      "id": "35",
       "title": "김포5",
       "img": "https://i.namu.wiki/i/5FGUIiyTGl3EkaSlnnRnmoAsPBMkL8w1tVdj5pgDOoydk2T0brSqYsWyLgGqyELwn5oP8HWRhF8A-p8ZyN4FtQ.webp"
     },
     {
-      "id": "20",
+      "id": "36",
       "title": "당정",
       "img": "https://cdn.imweb.me/thumbnail/20230522/31017371829ad.jpg"
     },
     {
-      "id": "21",
+      "id": "37",
       "title": "홍대",
       "img": "https://www.qplace.kr/content/images/2022/10/No.3185------.jpg"
     },
     {
-      "id": "22",
+      "id": "38",
       "title": "이태원",
       "img": "https://media.istockphoto.com/id/1286692956/ko/%EC%82%AC%EC%A7%84/%EC%9D%98%EC%9E%90%EC%99%80-%ED%85%8C%EC%9D%B4%EB%B8%94%EC%9D%B4-%EC%9E%88%EB%8A%94-%EB%B9%88-%EC%B9%B4%ED%8E%98-%EC%9D%B8%ED%85%8C%EB%A6%AC%EC%96%B4.jpg?s=612x612&w=0&k=20&c=dgWlZUPam-dJb_bRpXqCPUyRd-UWaYxCKiFkJT4fYSQ="
     },
     {
-      "id": "21",
+      "id": "39",
       "title": "홍대",
       "img": "https://www.qplace.kr/content/images/2022/10/No.3185------.jpg"
     }
@@ -330,57 +330,13 @@
     {
       "id": "4",
       "images": "https://gyeongju.go.kr/upload/content/thumb/20200429/AF0FBCACF6E141DEBAD30FDB6082D979.jpg"
-    },
-    {
-      "id": "dfc7",
-      "cafeName": "44",
-      "cafeInfo": "14",
-      "images": [
-        {
-          "img": {}
-        }
-      ]
-    },
-    {
-      "id": "1bcb",
-      "cafeName": "44",
-      "cafeInfo": "14",
-      "images": [
-        {
-          "img": {}
-        }
-      ]
-    },
-    {
-      "id": "a943",
-      "cafeName": "44",
-      "cafeInfo": "14",
-      "images": [
-        {
-          "img": {}
-        }
-      ]
-    },
-    {
-      "id": "4e10",
-      "cafeName": "44",
-      "cafeInfo": "14",
-      "images": [
-        {
-          "img": {}
-        }
-      ]
-    },
-    {
-      "id": "14b0",
-      "cafeName": "ddd",
-      "cafeInfo": "dddd",
-      "images": [
-        {
-          "img": {}
-        }
-      ]
     }
   ],
-  "Posts": []
+  "Posts": [
+    {
+      "id": "85ae",
+      "content": "ㅇㅇ",
+      "replies": []
+    }
+  ]
 }

--- a/src/json-server/db.json
+++ b/src/json-server/db.json
@@ -115,6 +115,119 @@
       "like": 85,
       "contents": "공차가 싫나요?",
       "hash": "홍"
+    },
+    {
+      "id": "11",
+      "title": "제목11",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "12",
+      "title": "제목12",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "13",
+      "title": "제목13",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+
+    {
+      "id": "14",
+      "title": "제목14",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "15",
+      "title": "제목15",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "16",
+      "title": "제목16",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "17",
+      "title": "제목17",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "18",
+      "title": "제목18",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "19",
+      "title": "제목19",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "20",
+      "title": "제목20",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "21",
+      "title": "제목21",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "22",
+      "title": "제목22",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "23",
+      "title": "제목23",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
+    },
+    {
+      "id": "24",
+      "title": "제목24",
+      "name": "공공",
+      "like": 85,
+      "contents": "공차가 싫나요?",
+      "hash": "홍"
     }
   ],
   "MainCt": [

--- a/src/json-server/db.json
+++ b/src/json-server/db.json
@@ -1,10 +1,6 @@
 {
   "MyPage": [
     {
-      "id": "1",
-      "name": "테스트하는 인간"
-    },
-    {
       "id": "2",
       "name": "늙은 사람"
     },
@@ -374,23 +370,17 @@
           "img": {}
         }
       ]
+    },
+    {
+      "id": "14b0",
+      "cafeName": "ddd",
+      "cafeInfo": "dddd",
+      "images": [
+        {
+          "img": {}
+        }
+      ]
     }
   ],
-  "Posts": [
-    {
-      "id": "97ff",
-      "content": "asasasasasasasasasasasasasasasasas",
-      "replies": []
-    },
-    {
-      "id": "8a1b",
-      "content": "ㅁㄴㅇㄴㅇㅁㄴㅇㅇㅁㅇㅁㄴ",
-      "replies": []
-    },
-    {
-      "id": "1f45",
-      "content": "ㅁㄴㅇㅁㄴ",
-      "replies": []
-    }
-  ]
+  "Posts": []
 }


### PR DESCRIPTION
메인페이지 페이지네이션 기능에서 그전 버튼을 누르면 한페이지에서 8개 보다 더 보이는 현상을 수정했습니다.
페이지네이션 자체 코드를 재활용가능하게 코드 수정 완료 헀습니다.
Lboard페이지에서 lounge페이지로 돌아가는 기능 추가
라운지 페이지 네이션 오류를 수정 후 기능을 온전히 쓸수있게 되었습니다.
라운지 HOVER시 다른색으로 변하게 수정하였습니다
페이지네이션 에서 기존 N페이지 라고 뜨는것 말고 해당 페이지면 해당 번호가 변하게 보이게 되었습니다.